### PR TITLE
Account For Lexers Without Any Shorthand Values

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,28 @@
+---
+name: Run Test Suite
+
+on: [
+  push,
+  pull_request
+  ]
+
+jobs:
+  run-tests-on-linux-ubuntu-2004:
+    name: Run Test Suite on Linux (Ubuntu 20.04)
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Syncat
+        run: |
+          python -m pip install --no-cache-dir --upgrade pip setuptools wheel
+          python -m pip install --editable . --ignore-installed --no-cache-dir --upgrade
+
+      - name: Install PyTest
+        run: |
+          python -m pip install pytest
+
+      - name: Run Test Suite
+        run: |
+          pytest

--- a/syncat/__init__.py
+++ b/syncat/__init__.py
@@ -65,7 +65,7 @@ def parse_args():
         type=str,
         choices=all_styles,
         default='solarized256',
-        metavar='STYLE',
+            metavar='STYLE',
         help='Syntax highlighting style. Choices:\n%s' % '\n'.join(all_styles)
     )
     parser.add_argument(
@@ -74,7 +74,8 @@ def parse_args():
         help='List help and options for the --lexer argument'
     )
 
-    all_lexers = sorted(get_all_lexers(), key=lambda l: l[1])
+    #import pdb; pdb.set_trace();
+    all_lexers = sorted(get_all_lexers(), key=lambda l: list(l[1]))
     all_lexer_aliases = [alias for lexer in all_lexers for alias in lexer[1]]
     lexers = parser.add_mutually_exclusive_group()
     lexers.add_argument(
@@ -88,7 +89,10 @@ def parse_args():
              '--LEXER such as --lexer json or --json',
         metavar='LEXER'
     )
-    for name, aliases, _, _ in all_lexers:
+    for name, aliases, _, _ in filter(
+            lambda lexer: len(lexer[1]) > 0,
+            all_lexers
+            ):
         lexers.add_argument(
             *('--%s' % a for a in aliases),
             dest='lexer',

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+import syncat
+
+
+@pytest.fixture()
+def mock_argparse(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "syncat",
+            "--lexer",
+            "json"
+            ]
+        )
+
+
+def test_parse_arguments_lexer(mock_argparse):
+    assert  syncat.parse_args().lexer == "json"


### PR DESCRIPTION
* A simple GitHub Actions workflow and test to demonstrate that later versions of Pygments breaks Syncat

Addresses #1 